### PR TITLE
add link to backstage / fore stage of issues

### DIFF
--- a/src/components/Menu/ForestageMenuContent.js
+++ b/src/components/Menu/ForestageMenuContent.js
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { useTheme } from '@emotion/react'
 import PropTypes from 'prop-types'
+import { Link, useParams } from 'react-router-dom'
+
 import flexJustifyAlign from '../../styles/flexJustifyAlign'
 import { issueIcon } from '../icons'
 
@@ -27,16 +29,18 @@ const ActivityDescription = styled.p`
   line-height: 2rem;
 `
 
-const Button = styled.button`
+const Button = styled(Link)`
   background-color: ${({ theme }) => theme.primary};
   color: ${({ theme }) => theme.secondary_900};
+  ${flexJustifyAlign()}
+  text-align: center;
   font-size: 1rem;
+  width: 55%;
   height: 2.5rem;
   padding: 0 1.5rem;
   border-radius: 1.125rem;
   border: none;
   margin: 0 auto;
-  display: block;
   margin-top: 1.5rem;
 `
 
@@ -48,6 +52,7 @@ const ForestageMenuContent = ({
   beginDate,
   finishDate
 }) => {
+  const { url } = useParams()
   const theme = useTheme()
   return (
     <>
@@ -62,7 +67,9 @@ const ForestageMenuContent = ({
         </ActivityDuration>
         <ActivityDescription>{description}</ActivityDescription>
       </ActivityWrapper>
-      {userId === issueUserId && <Button>進入此後台</Button>}
+      {userId === issueUserId && (
+        <Button to={`../backstage/issues/${url}`}>進入此後台</Button>
+      )}
     </>
   )
 }

--- a/src/components/Navbar/BackstageNavbar.js
+++ b/src/components/Navbar/BackstageNavbar.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, Link, useParams } from 'react-router-dom'
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
 import { useTheme } from '@emotion/react'
@@ -58,6 +58,7 @@ const Button = styled(ButtonOrigin)`
 
 export const BackstageNavbar = ({ iconName, title }) => {
   const theme = useTheme()
+  const { url } = useParams()
   const location = useLocation()
   return (
     <Navbar>
@@ -66,7 +67,9 @@ export const BackstageNavbar = ({ iconName, title }) => {
         <span>{title}</span>
       </div>
       {location.pathname.indexOf('/backstage/issues') === 0 && (
-        <Button backgroundColor={theme.primary}>進入此前台</Button>
+        <Button backgroundColor={theme.primary} as={Link} to={`/issues/${url}`}>
+          進入此前台
+        </Button>
       )}
     </Navbar>
   )


### PR DESCRIPTION
2021.10.07

- [x] 補「進入此後台」的連結
- [x] 補「進入此前台」的連結

---

結果這張票只有這個要做＠＠“
註冊、登入成功後的跳轉畫面，本來就是跳轉到**後台**的，所以我把我這張票裡面的這項刪掉唷 : D

(gif 圖檔有更新：進入前後台)

![螢幕錄製 2021-10-07 下午8 19 49](https://user-images.githubusercontent.com/80995032/136382895-42ef0d6e-bfd8-48f1-9778-4731493a8ca8.gif)
